### PR TITLE
Disable default/udft-HCTH76-gradient test

### DIFF
--- a/dft-libxc/parallel/default/udft-HCTH76-gradient.inp
+++ b/dft-libxc/parallel/default/udft-HCTH76-gradient.inp
@@ -17,6 +17,11 @@ C1
  C           6.0  -0.4937258731  -0.0052493598   0.1881706036
  H           1.0  -1.5086084353   0.0318142577  -0.2223596448
  F           9.0   0.2289975364   1.1455552686  -0.0745345798
- $END!
-!TRAVIS-CI SMALL
-! 
+ $END
+
+!
+! At line 2442 of file dftgrd.f (unit = 22, file = 'udft-HCTH76-gradient.F22')
+! Fortran runtime error: End of file
+!
+!TRAVIS-CI SKIP
+!


### PR DESCRIPTION
Test default/udft-HCTH76-gradient is disabled due to problems gradient calculation:

```gamess.gfortran.x udft-HCTH76-gradient -scr /home/ger/scratch < /dev/null
At line 2442 of file dftgrd.f (unit = 22, file = '$SCR/udft-HCTH76-gradient.F22')
Fortran runtime error: End of file

Error termination. Backtrace:
#0  0x7ffaa6538da1 in ???
#1  0x7ffaa65398e9 in ???
#2  0x7ffaa653a59f in ???
#3  0x7ffaa677be7b in ???
#4  0x7ffaa677c8ef in ???
#5  0x7ffaa677c9d4 in ???
#6  0x7ffaa677ee3a in ???
#7  0x7ffaa677f724 in ???
#8  0x93c590 in dftset_
        at /dev/shm/gamess.libxc/object/dftgrd.f:2442
#9  0x94555e in dftder_
        at /dev/shm/gamess.libxc/object/dftgrd.f:7701
#10  0xf2e4ac in jkder_
        at /dev/shm/gamess.libxc/object/grd2a.F:3053
#11  0x4031bc in hfgrad_
        at /dev/shm/gamess.libxc/object/gamess.F:2161
#12  0x40e8e3 in gradx_
        at /dev/shm/gamess.libxc/object/gamess.F:1760
#13  0x40f952 in brnchx_
        at /dev/shm/gamess.libxc/object/gamess.F:1058
#14  0x410551 in gamess
        at /dev/shm/gamess.libxc/object/gamess.F:731
#15  0x40270c in main
        at /dev/shm/gamess.libxc/object/gamess.F:489```
